### PR TITLE
adding PreserveReferencesHandling to json serializer

### DIFF
--- a/Mep.Api/Startup.cs
+++ b/Mep.Api/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 
 namespace Mep.Api
 {
@@ -24,7 +25,12 @@ namespace Mep.Api
     // This method gets called by the runtime. Use this method to add services to the container.
     public void ConfigureServices(IServiceCollection services)
     {
-      services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+      services.AddMvc()
+              .SetCompatibilityVersion(CompatibilityVersion.Version_2_2)
+              .AddJsonOptions(opt => {
+                opt.SerializerSettings.PreserveReferencesHandling = PreserveReferencesHandling.Objects;
+              });
+              
       services.AddDbContext<ApplicationContext>
       (options =>
       {

--- a/Mep.Business/Models/Profiles/CcgProfile.cs
+++ b/Mep.Business/Models/Profiles/CcgProfile.cs
@@ -6,8 +6,7 @@ namespace Mep.Business.Models.Profiles
   {
     public CcgProfile()
     {
-      CreateMap<Entities.Ccg, Models.Ccg>()
-      .ForMember(c => c.Patients, opt => opt.Ignore());
+      CreateMap<Entities.Ccg, Models.Ccg>();
 
       CreateMap<Models.Ccg, Entities.Ccg>();
     }

--- a/Mep.Business/Models/Profiles/GenderTypeProfile.cs
+++ b/Mep.Business/Models/Profiles/GenderTypeProfile.cs
@@ -6,8 +6,7 @@ namespace Mep.Business.Models.Profiles
   {
     public GenderTypeProfile()
     {
-      CreateMap<Entities.GenderType, Models.GenderType>()
-      .ForMember(g => g.ModifiedByUser, opt => opt.Ignore());
+      CreateMap<Entities.GenderType, Models.GenderType>();
 
       CreateMap<Models.GenderType, Entities.GenderType>();
     }

--- a/Mep.Business/Models/Profiles/ReferralProfile.cs
+++ b/Mep.Business/Models/Profiles/ReferralProfile.cs
@@ -6,9 +6,7 @@ namespace Mep.Business.Models.Profiles
   {
     public ReferralProfile()
     {
-      CreateMap<Entities.Referral, Models.Referral>()
-      .ForPath(dest => dest.Patient.Referrals, opt => opt.Ignore());
-
+      CreateMap<Entities.Referral, Models.Referral>();
       CreateMap<Models.Referral, Entities.Referral>();
     }
   }

--- a/Mep.Business/Models/Profiles/UserProfile.cs
+++ b/Mep.Business/Models/Profiles/UserProfile.cs
@@ -6,8 +6,7 @@ namespace Mep.Business.Models.Profiles
   {
     public UserProfile()
     {
-      CreateMap<Entities.User, Models.User>()
-      .ForMember(u => u.ModifiedByUser, opt => opt.Ignore());
+      CreateMap<Entities.User, Models.User>();
 
       CreateMap<Models.User, Entities.User>();
     }


### PR DESCRIPTION
opt.SerializerSettings.PreserveReferencesHandling = PreserveReferencesHandling.Objects adds references e.g.
{
    "$id": "1",
        "referrals": [
            {
                "$ref": "1"
            }
        ],
into the JSON.
This allows us to remove the .ForPath(dest => dest.Patient.Referrals, opt => opt.Ignore()); which was causing the Patient and Referrals objects to be ignored